### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 
-os:
-    - linux
+dist: trusty
 
 matrix:
   include:


### PR DESCRIPTION
dist: trusty to force not xenial, which fails on oraclejdk8