### PR TITLE
Avoid //@Test(expected, allow " #Test(expect" only

### DIFF
--- a/junit4-to-5.sed
+++ b/junit4-to-5.sed
@@ -219,9 +219,9 @@ s/^import org\.junit\.\*;/import org.junit.jupiter.api.*;/
 }
 
 # Assumes an indentation of 4 spaces
-/@Test.*expected/,/^    }/ {
+/^[[:space:]]*@Test.*expected/,/^    }/ {
 
-    /@Test.*expected/ {
+    /^[[:space:]]*@Test.*expected/ {
         s/.*[= ](.*\.class).*/        \1/
         h
         s/.*/    @Test/

--- a/junit4-to-5.sed
+++ b/junit4-to-5.sed
@@ -113,7 +113,7 @@ s/org\.junit\.experimental\.categories\.Category/org.junit.jupiter.api.Tag/g
 /^import org\.junit\.Rule;/,$ {
     s|^[[:space:]]*@Rule|& // see org.junit.jupiter.api.extension.ExtendWith|
 }
-s|^[[:space:]]*(@org\.junit\.)?(Class)?Rule|& // see org.junit.jupiter.api.extension.ExtendWith|
+s|^[[:space:]]*@(org\.junit\.)?(Class)?Rule|& // see org.junit.jupiter.api.extension.ExtendWith|
 
 #TODO IncludeTags, imports. categories.* (Categories/Category) conflict (Tag/Excludetags)
 /^import org\.junit\.experimental\.categories\.(Categories|\*);/,$ {

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -28,3 +28,4 @@ org.junit.jupiter.api.Assertions.assertNull(value, "message");
 org.junit.jupiter.api.Assertions.assertNotNull(value, "message");
 org.junit.jupiter.api.Assertions.assertEquals(2 , fooDAO.findFoo(obj.get().getId()).size(), "Expect 2 record " );
 @org.junit.ClassRule // see org.junit.jupiter.api.extension.ExtendWith
+    //@Test(expected = FooException.class)

--- a/test/test.txt
+++ b/test/test.txt
@@ -28,3 +28,4 @@ org.junit.Assert.assertNull("message", value);
 org.junit.Assert.assertNotNull("message", value);
 org.junit.Assert.assertEquals("Expect 2 record " , 2 ,fooDAO.findFoo(obj.get().getId()).size());
 @org.junit.ClassRule
+    //@Test(expected = FooException.class)


### PR DESCRIPTION
Hopefully this unbreaks more cases (`// @Test(expected`) than it breaks (`@Foo @Test(expected`?).